### PR TITLE
distributed_locker: implement max shared holders

### DIFF
--- a/lockgate.go
+++ b/lockgate.go
@@ -23,6 +23,11 @@ type AcquireOptions struct {
 	NonBlocking bool
 	Timeout     time.Duration
 	Shared      bool
+	// MaxSharedHolders, if greater than 0 and if Shared is true, indicates that the lock
+	// acquisition should not proceed if there are more than this number of current holders.
+	//
+	// Note: This is currently only implemented for DistributedLockerBackend.
+	MaxSharedHolders int64 `json:"maxSharedHolders"`
 
 	OnWaitFunc      func(lockName string, doWait func() error) error
 	OnLostLeaseFunc func(lock LockHandle) error

--- a/pkg/distributed_locker/distributed_locker.go
+++ b/pkg/distributed_locker/distributed_locker.go
@@ -41,7 +41,10 @@ RETRY_ACQUIRE:
 		}
 	}
 
-	if lockHandle, err := l.Backend.Acquire(lockName, AcquireOptions{Shared: opts.Shared}); IsErrShouldWait(err) {
+	if lockHandle, err := l.Backend.Acquire(lockName, AcquireOptions{
+		Shared:           opts.Shared,
+		MaxSharedHolders: opts.MaxSharedHolders,
+	}); IsErrShouldWait(err) {
 		if opts.NonBlocking {
 			debug("(acquire %q) non blocking acquire done: lock not taken!", lockName)
 			return false, lockgate.LockHandle{}, nil

--- a/pkg/distributed_locker/distributed_locker_backend.go
+++ b/pkg/distributed_locker/distributed_locker_backend.go
@@ -50,7 +50,8 @@ type DistributedLockerBackend interface {
 }
 
 type AcquireOptions struct {
-	Shared bool `json:"shared"`
+	Shared           bool  `json:"shared"`
+	MaxSharedHolders int64 `json:"maxSharedHolders"`
 }
 
 type LockLeaseRecord struct {

--- a/pkg/distributed_locker/optimistic_locking_storage_base_backend.go
+++ b/pkg/distributed_locker/optimistic_locking_storage_base_backend.go
@@ -60,7 +60,7 @@ RETRY_ACQUIRE:
 				// If MaxSharedHolders is set, and the existing lease has more than this
 				// number of holders, then continue waiting.
 				if opts.MaxSharedHolders > 0 && oldLease.SharedHoldersCount >= opts.MaxSharedHolders {
-					debug("(acquire lock %q) shared holders counter exceed desired max shared holders %d: %#v",
+					debug("(acquire lock %q) shared holders counter exceed desired max shared holders %d: %s %#v",
 						oldLease.SharedHoldersCount, lockName, oldLease)
 					return lockgate.LockHandle{}, ErrShouldWait
 				}


### PR DESCRIPTION
This change allows us to leverage the existing `SharedHoldersCount` on leases to dictate how many resources can acquire a lock at the same time.

_This PR is not intended for merge_ - currently it seems this is not possible to easily implement for the other locking backends in this library, so it might not get accepted upstream.